### PR TITLE
Update to scoped xterm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "throttle-debounce": "5.0.0",
-    "xterm": "5.1.0",
-    "xterm-addon-canvas": "0.4.0"
+    "@xterm/xterm": "5.5.0",
+    "@xterm/addon-canvas": "0.7.0"
   }
 }

--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -19,8 +19,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Terminal } from "xterm";
-import { CanvasAddon } from 'xterm-addon-canvas';
+import { Terminal } from "@xterm/xterm";
+import { CanvasAddon } from '@xterm/addon-canvas';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';

--- a/src/ContainerTerminal.css
+++ b/src/ContainerTerminal.css
@@ -1,4 +1,4 @@
-@import "xterm/css/xterm.css";
+@import "@xterm/xterm/css/xterm.css";
 
 .terminal {
     /* 5px all around and on right +11 since the scrollbar is 11px wide */

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -20,8 +20,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
-import { Terminal } from "xterm";
-import { CanvasAddon } from 'xterm-addon-canvas';
+import { Terminal } from "@xterm/xterm";
+import { CanvasAddon } from '@xterm/addon-canvas';
 import { ErrorNotification } from './Notification.jsx';
 
 import * as client from './client.js';


### PR DESCRIPTION
## Summary
- upgrade `package.json` to use scoped `@xterm` packages
- switch JS imports to the new packages
- adjust CSS import path for xterm styles
- run `npm install` to refresh lockfile

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684196a854ec832fa27de00f18d00467