### PR TITLE
Fix eslint errors

### DIFF
--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -47,11 +47,9 @@ const HealthLogBlock = ({ log }) => {
     const toggleExpanded = () => setExpanded(!expanded);
 
     const actions = (
-        <>
-            <CodeBlockAction>
-                <ClipboardCopyButton variant="plain" aria-label={_("Copy to clipboard")} text={log.Output} />
-            </CodeBlockAction>
-        </>
+        <CodeBlockAction>
+            <ClipboardCopyButton variant="plain" aria-label={_("Copy to clipboard")} text={log.Output} />
+        </CodeBlockAction>
     );
 
     let output = log.Output.split("\n");

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -12,7 +12,7 @@ import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberIn
 import { InputGroup, InputGroupText } from "@patternfly/react-core/dist/esm/components/InputGroup";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Tab, TabTitleText, Tabs } from "@patternfly/react-core/dist/esm/components/Tabs";
-import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
+import { Text } from "@patternfly/react-core/dist/esm/components/Text";
 import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/esm/components/ToggleGroup";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -5,7 +5,6 @@ import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
-import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 


### PR DESCRIPTION
## Summary
- remove unnecessary fragment in ContainerHealthLogs
- clean up unused imports
- ensure linting passes

## Testing
- `npm run eslint`

------
https://chatgpt.com/codex/tasks/task_e_68419b26d148832fb637a2f0ab0e0579