### PR TITLE
Fix stylelint errors

### DIFF
--- a/src/docker.scss
+++ b/src/docker.scss
@@ -1,8 +1,8 @@
-@use "ct-card.scss";
-@use "page.scss";
+@use "ct-card";
+@use "page";
 @import "global-variables";
 // For pf-v5-line-clamp
-@import "@patternfly/patternfly/sass-utilities/mixins.scss";
+@import "@patternfly/patternfly/sass-utilities/mixins";
 // For pf-u-disabled-color-100
 @import "@patternfly/patternfly/utilities/Text/text.css";
 


### PR DESCRIPTION
## Summary
- remove `.scss` suffixes from `@use` and `@import` paths in docker.scss

## Testing
- `npm run stylelint`

------
https://chatgpt.com/codex/tasks/task_e_68419cb66ccc832fa1a338c04100c047