### PR TITLE
Fix container name display and log container list

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -310,10 +310,14 @@ class Containers extends React.Component {
             [mem_text, mem] = utils.format_memory_and_limit(containerStats);
         }
 
+        let containerName = container.Name;
+        if (containerName?.startsWith("/"))
+            containerName = containerName.substring(1);
+
         const info_block = (
             <div className="container-block">
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                    <span className="container-name">{container.Name}</span>
+                    <span className="container-name">{containerName}</span>
                     {isToolboxContainer && <Badge className='ct-badge-toolbox'>toolbox</Badge>}
                     {isDistroboxContainer && <Badge className='ct-badge-distrobox'>distrobox</Badge>}
                 </Flex>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -153,9 +153,12 @@ class Application extends React.Component {
 
     initContainers() {
         return client.getContainers()
-                .then(containerList => Promise.all(
-                    containerList.map(container => client.inspectContainer(container.Id))
-                ))
+                .then(containerList => {
+                    console.log(containerList);
+                    return Promise.all(
+                        containerList.map(container => client.inspectContainer(container.Id))
+                    );
+                })
                 .then(containerDetails => {
                     this.setState(prevState => {
                         const copyContainers = prevState.containers || {};


### PR DESCRIPTION
## Summary
- strip leading slash from container names
- log fetched container list before inspecting containers

## Testing
- `npm run eslint`
- `npm run stylelint`


------
https://chatgpt.com/codex/tasks/task_e_689d3cfa362c832f87bbd07ded4aba80